### PR TITLE
Fix user delete #23

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -7,5 +7,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
     redirect_to root_path, alert: 'ゲストユーザーは削除できません。' if resource.email == 'guest@example.com'
   end
 
-  def destroy; end
+  def destroy
+    @user = User.find(params[:format])
+    @user.destroy
+    redirect_to root_url, notice: 'アカウントを削除しました｡ またのご利用お待ちしています｡' if @user.destroy
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,9 @@ class UsersController < ApplicationController
     @posts = @user.posts.paginate(page: params[:page], per_page: 5)
   end
 
-  def edit; end
+  def edit
+    @user = User.find(params[:id])
+  end
 
   def update; end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -40,12 +40,15 @@
     <div class="actions">
       <%= f.submit "更新", class: "btn" %>
     </div>
+
   <% end %>
 
   <div class="withdraw">
-    <h3>アカウント削除</h3>
-    <p>アカウントを削除します  <%= button_to "アカウント消去", registration_path(resource_name), data: { confirm: "本当にアカウントを削除してもよろしいですか?" }, method: :delete, class:"btn" %></p>
+    <h3>Tabicolleから退会する</h3>
+    <p>退会手続きをされますと､アカウントが削除され再びログインできなくなります｡ </p>
+    <%= button_to '退会', user_registration_path(@user), data: { confirm: "本当にアカウントを削除して､退会してもよろしいですか?" },  method: :delete,class:"btn"  %>
   </div>
+
 
   <%= link_to "戻る", :back %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -46,7 +46,7 @@
   <div class="withdraw">
     <h3>Tabicolleから退会する</h3>
     <p>退会手続きをされますと､アカウントが削除され再びログインできなくなります｡ </p>
-    <%= button_to '退会', user_registration_path(@user), data: { confirm: "本当にアカウントを削除して､退会してもよろしいですか?" },  method: :delete,class:"btn"  %>
+    <%= button_to '退会', user_registration_path(@user), data: { confirm: "本当にアカウントを削除して､退会してもよろしいですか?" }, method: :delete, class:"btn"  %>
   </div>
 
 


### PR DESCRIPTION
**Why**

プロフィール編集画面から退会ボタンを押しても､処理がなかったから

**what**

- registration_controllerのdestroyアクションに退会処理の記述
- プロフィール画面のビューのリンクを修正